### PR TITLE
Nil check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source :rubygems
 gem 'ffi'
 
 group :test do
-  gem 'rspec', '1.3.1'
+  gem 'rspec', '2.7.0'
   gem 'jeweler'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    diff-lcs (1.1.3)
     ffi (1.0.9)
     git (1.2.5)
     jeweler (1.6.4)
@@ -8,7 +9,14 @@ GEM
       git (>= 1.2.5)
       rake
     rake (0.9.2)
-    rspec (1.3.1)
+    rspec (2.7.0)
+      rspec-core (~> 2.7.0)
+      rspec-expectations (~> 2.7.0)
+      rspec-mocks (~> 2.7.0)
+    rspec-core (2.7.1)
+    rspec-expectations (2.7.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.7.0)
 
 PLATFORMS
   ruby
@@ -16,4 +24,4 @@ PLATFORMS
 DEPENDENCIES
   ffi
   jeweler
-  rspec (= 1.3.1)
+  rspec (= 2.7.0)

--- a/lib/levenshtein.rb
+++ b/lib/levenshtein.rb
@@ -1,12 +1,27 @@
 require 'ffi'
 
 module Levenshtein
-  extend FFI::Library
+  class << self
+    extend FFI::Library
 
-  # Try loading in order.
-  library = File.dirname(__FILE__) + "/../ext/levenshtein/levenshtein"
-  candidates = ['.bundle', '.so', '.dylib', ''].map { |ext| library + ext }
-  ffi_lib(candidates)
-  
-  attach_function :distance, :levenshtein, [:string, :string], :int
+    # Try loading in order.
+    library = File.dirname(__FILE__) + "/../ext/levenshtein/levenshtein"
+    candidates = ['.bundle', '.so', '.dylib', ''].map { |ext| library + ext }
+    ffi_lib(candidates)
+
+    def distance(str1, str2)
+      validate(str1)
+      validate(str2)
+      ffi_distance(str1, str2)
+    end
+
+    private
+    def validate(arg)
+      unless arg.kind_of?(String)
+        raise TypeError, "wrong argument type #{arg.class} (expected String)"
+      end
+    end
+
+    attach_function :ffi_distance, :levenshtein, [:string, :string], :int
+  end
 end

--- a/lib/levenshtein.rb
+++ b/lib/levenshtein.rb
@@ -9,11 +9,15 @@ module Levenshtein
     candidates = ['.bundle', '.so', '.dylib', ''].map { |ext| library + ext }
     ffi_lib(candidates)
 
+    # Safe version of distance, checks that arguments are really strings.
     def distance(str1, str2)
       validate(str1)
       validate(str2)
       ffi_distance(str1, str2)
     end
+
+    # Unsafe version. Results in a segmentation fault if passed nils!
+    attach_function :ffi_distance, :levenshtein, [:string, :string], :int
 
     private
     def validate(arg)
@@ -21,7 +25,5 @@ module Levenshtein
         raise TypeError, "wrong argument type #{arg.class} (expected String)"
       end
     end
-
-    attach_function :ffi_distance, :levenshtein, [:string, :string], :int
   end
 end

--- a/spec/levenshtein_spec.rb
+++ b/spec/levenshtein_spec.rb
@@ -19,4 +19,15 @@ describe Levenshtein do
       Levenshtein.distance(w2, w1).should == d
     end
   end
+
+  it "should raise an error if either argument is nil" do
+    expect { Levenshtein.distance("", nil) }.to raise_error TypeError
+    expect { Levenshtein.distance(nil, "") }.to raise_error TypeError
+  end
+
+  it "should raise an error if either argument is something else than a string" do
+    expect { Levenshtein.distance("woah", /woah/) }.to raise_error TypeError
+    expect { Levenshtein.distance(5.3, "5.3") }.to raise_error TypeError
+    expect { Levenshtein.distance(Object.new, "Hello") }.to raise_error TypeError
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,1 @@
-require 'spec'
-
 require File.dirname(__FILE__) + "/../lib/levenshtein"


### PR DESCRIPTION
Fixed the "segmentation fault on nil arguments" issue by adding a check that the given arguments are really strings. If given something else will raise a TypeError. I also updated RSpec to version 2.
