### PR TITLE
Removed duplicate ffi dependency

### DIFF
--- a/levenshtein-ffi.gemspec
+++ b/levenshtein-ffi.gemspec
@@ -44,18 +44,15 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<ffi>, ["~> 1.1.5"])
-      s.add_runtime_dependency(%q<ffi>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
       s.add_dependency(%q<ffi>, ["~> 1.1.5"])
-      s.add_dependency(%q<ffi>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
     s.add_dependency(%q<ffi>, ["~> 1.1.5"])
-    s.add_dependency(%q<ffi>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
   end


### PR DESCRIPTION
This didn't make much sense.. but I detected it when I saw this in my `Gemfile.lock` (which is no doubt Bundler's issue but it made me look at the dependencies you had!):

```
    levenshtein-ffi (1.0.3)
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
      ffi (~> 1.1.5)
```
