### PR TITLE
Added the empty method Init_levenshtein to the C extension

### DIFF
--- a/ext/levenshtein/levenshtein.c
+++ b/ext/levenshtein/levenshtein.c
@@ -10,6 +10,10 @@
 
 # define min(x, y) ((x) < (y) ? (x) : (y))
 
+void Init_levenshtein () {
+  // Empty method body
+}
+
 unsigned int levenshtein (const char *word1, const char *word2) {
     size_t len1 = strlen(word1),
            len2 = strlen(word2);


### PR DESCRIPTION
To build this gem on Windows it is necessary that the C extension
exports a symbol with the name Init_levenshtein. The empty method body
does just that and makes it possible to install the gem on windows.
