### PR TITLE
Include LICENSE in gem

### DIFF
--- a/levenshtein-ffi.gemspec
+++ b/levenshtein-ffi.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.markdown",
     "Gemfile",
     "README.markdown",
+    "LICENSE",
     "Rakefile",
     "VERSION",
     "ext/levenshtein/.gitignore",


### PR DESCRIPTION
This adds the LICENSE to the gemspec so it is included in the gem. Any distribution of the code should also include the license and copyright notice.
