### PR TITLE
Fix installation with rubygems 3.4+

### DIFF
--- a/ext/levenshtein/extconf.rb
+++ b/ext/levenshtein/extconf.rb
@@ -1,2 +1,3 @@
 require 'mkmf'
 create_makefile('levenshtein')
+system('make install')

--- a/lib/levenshtein.rb
+++ b/lib/levenshtein.rb
@@ -5,8 +5,9 @@ module Levenshtein
     extend FFI::Library
 
     # Try loading in order.
-    library = File.dirname(__FILE__) + "/../ext/levenshtein/levenshtein"
-    candidates = ['.bundle', '.so', '.dylib', ''].map { |ext| library + ext }
+    candidates = $LOAD_PATH.flat_map do |p|
+      ['.bundle', '.so', '.dylib', ''].map { |e| File.join(p, "levenshtein#{e}") }
+    end
     ffi_lib(candidates)
 
     # Safe version of distance, checks that arguments are really strings.


### PR DESCRIPTION
Rubygems 3.4.0 introduced a change that cleans the build artifacts from the ext directory. However, this gem depends on the compiled C function being there as a shared object, so would break with an output similar to:
```
🕙 14:23:02 ❯ docker run -it --rm -v (pwd):/app -w /app ruby:3.2.0 bash
root@72d3ddb49511:/app# gem install levenshtein-ffi
Fetching levenshtein-ffi-1.1.0.gem
Fetching ffi-1.15.5.gem
Building native extensions. This could take a while...
Successfully installed ffi-1.15.5
Building native extensions. This could take a while...
Successfully installed levenshtein-ffi-1.1.0
2 gems installed
root@72d3ddb49511:/app# irb
irb(main):001:0> require 'levenshtein-ffi'
/usr/local/bundle/gems/ffi-1.15.5/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library '/usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein.bundle': /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein.bundle: cannot open shared object file: No such file or directory. (LoadError)
Could not open library '/usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein.so': /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein.so: cannot open shared object file: No such file or directory.
Could not open library '/usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein.dylib': /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein.dylib: cannot open shared object file: No such file or directory.
Could not open library '/usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein': /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/../ext/levenshtein/levenshtein: cannot open shared object file: No such file or directory
	from /usr/local/bundle/gems/ffi-1.15.5/lib/ffi/library.rb:99:in `map'
	from /usr/local/bundle/gems/ffi-1.15.5/lib/ffi/library.rb:99:in `ffi_lib'
	from /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/levenshtein.rb:10:in `singleton class'
	from /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/levenshtein.rb:4:in `<module:Levenshtein>'
	from /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/levenshtein.rb:3:in `<top (required)>'
	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /usr/local/bundle/gems/levenshtein-ffi-1.1.0/lib/levenshtein-ffi.rb:1:in `<top (required)>'
	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from (irb):1:in `<main>'
	from /usr/local/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
	from /usr/local/bin/irb:25:in `load'
	from /usr/local/bin/irb:25:in `<main>'
<internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- levenshtein-ffi (LoadError)
	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from (irb):1:in `<main>'
	from /usr/local/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
	from /usr/local/bin/irb:25:in `load'
	from /usr/local/bin/irb:25:in `<main>'
```
when required.

This PR runs `make install` when installing the gem to place the complied file into the $LOAD_PATH, and then instructs `ffi-lib` to search for it in there. This appears to fix the issue.